### PR TITLE
Added code to load defaults settings from config.xml

### DIFF
--- a/media/k2app/app/templates/attachments/add.html
+++ b/media/k2app/app/templates/attachments/add.html
@@ -11,10 +11,11 @@
 			<div class="ov-hidden jw--element--single">
 				<div class="jw--element--single jw--file--btn">
 				    <input type="file" data-widget="uploader" data-url="index.php?option=com_k2&task=attachments.upload&id=<%- id %>&itemId=<%- itemId %>&format=json" data-callback="attachments:upload:<%- cid %>" name="file" />
-					<input type="hidden" name="attachments[<%- cid %>][file]" value="<%- file %>" />
 					<span class="jw--btn jw--file-fakebtn">
 						<i class="fa fa-upload"></i> <span><%= l('K2_UPLOAD') %></span>
 					</span>
+					<input class="jw--small--input" readonly="readonly" type="text" name="attachments[<%- cid %>][file]" value="<%- file %>" />
+					
 				</div>
 			
 				<div class="jw--element--single">    

--- a/script.k2.php
+++ b/script.k2.php
@@ -235,11 +235,18 @@ class Com_K2InstallerScript
 			}
 		}
 
-		// Set the default image sizes for new installs
+		// Set the default config parameters for new installs
 		if ($type == 'install')
 		{
 			$params = JComponentHelper::getParams('com_k2');
 
+			// load the defaults from the config file on new installs
+			$xmlForm = simplexml_load_file($src.'/administrator/components/com_k2/config.xml');
+			foreach ($xmlForm->xpath('fieldset') as $fieldset) {
+				$this->addDefaults($params, $fieldset);
+			}
+						
+			// set the default image sizes
 			$imageSizes = array();
 
 			$size = new stdClass;
@@ -295,6 +302,20 @@ class Com_K2InstallerScript
 		$parent->getParent()->set('redirect_url', 'index.php?option=com_k2&view=installation');
 	}
 
+	private function addDefaults (&$params, $xml){
+		// set default value if we've one
+		$name = (string) $xml['name'];
+		$default = (string) $xml['default'];
+		
+		if (!empty($name) && !empty($default)) {
+			$params->set($name, $default);
+		}
+		// recurse further
+		foreach ($xml->children() as $child) {
+			$this->addDefaults($params, $child);
+		}
+	}
+	
 	public function uninstall($parent)
 	{
 		// Get database


### PR DESCRIPTION
On a fresh install, the params from the config.xml were not loaded. As a consequence, the enable_css was not set and thus the k2.css was not loaded on the front-end. 

Just opening and savind the k2 configuration parameters worked as a work around. The solution is to extract the default parameters from the config.xml file and store these in the database.

This issue is potentially related to bug #2. I've asked for some more details to confirm.

Cheers, Paul